### PR TITLE
Update to Android studio Arctic Fox and kotlin 1.4.20

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -34,4 +34,5 @@ android {
             isMinifyEnabled = false
         }
     }
+
 }

--- a/androidApp/src/main/java/com/radityalabs/qualitymatter/androidApp/MainActivity.kt
+++ b/androidApp/src/main/java/com/radityalabs/qualitymatter/androidApp/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.radityalabs.qualitymatter.androidApp
 
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember

--- a/androidApp/src/main/java/com/radityalabs/qualitymatter/androidApp/ui/Theme.kt
+++ b/androidApp/src/main/java/com/radityalabs/qualitymatter/androidApp/ui/Theme.kt
@@ -2,6 +2,8 @@ package com.radityalabs.qualitymatter.androidApp.ui
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.MaterialTheme.shapes
+import androidx.compose.material.MaterialTheme.typography
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10")
-        classpath("com.android.tools.build:gradle:4.1.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}")
+        classpath("com.android.tools.build:gradle:${Versions.androidGradle}")
+        classpath("com.android.tools.build:builder:${Versions.androidGradle}")
+        classpath("com.android.tools.build:builder-model:${Versions.androidGradle}")
     }
 }
 group = "com.radityalabs.qualitymatter"

--- a/buildSrc/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
-    const val kotlin = "1.4.10"
-    const val androidGradle = "4.2.0-alpha16"
+    const val kotlin = "1.4.20"
+    const val androidGradle = "7.0.0-alpha02"
     const val appCompat = "1.2.0"
     const val constraintlayout = "2.0.4"
 
@@ -8,8 +8,8 @@ object Versions {
 
     const val mockk = "1.9.3"
 
-    const val compose = "1.0.0-alpha07"
-    const val composeNav = "1.0.0-alpha02"
-    const val composePaging = "1.0.0-alpha02"
-    const val composeAppComponist = "0.3.3.1"
+    const val compose = "1.0.0-alpha08"
+    const val composeNav = "1.0.0-alpha03"
+    const val composePaging = "1.0.0-alpha03"
+    const val composeAppComponist = "0.4.0"
 }

--- a/buildSrc/src/main/kotlin/plugin/JetpackComposePlugin.kt
+++ b/buildSrc/src/main/kotlin/plugin/JetpackComposePlugin.kt
@@ -33,17 +33,16 @@ class JetpackComposePlugin : Plugin<Project> {
 
         project.dependencies.run {
             addImplementation("androidx.compose.animation:animation:${Versions.compose}")
+            addImplementation("androidx.compose.compiler:compiler:${Versions.compose}")
             addImplementation("androidx.compose.foundation:foundation:${Versions.compose}")
-            addImplementation("androidx.compose.foundation:foundation-layout:${Versions.compose}")
             addImplementation("androidx.compose.material:material:${Versions.compose}")
-            addImplementation("androidx.compose.material:material-icons-extended:${Versions.compose}")
             addImplementation("androidx.compose.runtime:runtime:${Versions.compose}")
             addImplementation("androidx.compose.ui:ui:${Versions.compose}")
-            addImplementation("androidx.ui:ui-tooling:${Versions.compose}")
+            addImplementation("androidx.compose.ui:ui-tooling:${Versions.compose}")
+            addAndroidTestImplementation("androidx.compose.ui:ui-test:${Versions.compose}")
+            addImplementation("dev.chrisbanes.accompanist:accompanist-coil:${Versions.composeAppComponist}")
             addImplementation("androidx.navigation:navigation-compose:${Versions.composeNav}")
             addImplementation("androidx.paging:paging-compose:${Versions.composePaging}")
-
-            addImplementation("dev.chrisbanes.accompanist:accompanist-coil:${Versions.composeAppComponist}")
         }
 
     }

--- a/buildSrc/src/main/kotlin/plugin/jetpack-compose-precompile.gradle.kts
+++ b/buildSrc/src/main/kotlin/plugin/jetpack-compose-precompile.gradle.kts
@@ -18,16 +18,16 @@ android {
 
 dependencies {
     implementation("androidx.compose.animation:animation:${Versions.compose}")
+    implementation("androidx.compose.compiler:compiler:${Versions.compose}")
     implementation("androidx.compose.foundation:foundation:${Versions.compose}")
-    implementation("androidx.compose.foundation:foundation-layout:${Versions.compose}")
     implementation("androidx.compose.material:material:${Versions.compose}")
-    implementation("androidx.compose.material:material-icons-extended:${Versions.compose}")
     implementation("androidx.compose.runtime:runtime:${Versions.compose}")
     implementation("androidx.compose.ui:ui:${Versions.compose}")
-    implementation("androidx.ui:ui-tooling:${Versions.compose}")
+    implementation("androidx.compose.ui:ui-tooling:${Versions.compose}")
+    androidTestImplementation("androidx.compose.ui:ui-test:${Versions.compose}")
+    implementation("dev.chrisbanes.accompanist:accompanist-coil:${Versions.composeAppComponist}")
     implementation("androidx.navigation:navigation-compose:${Versions.composeNav}")
     implementation("androidx.paging:paging-compose:${Versions.composePaging}")
-    implementation("dev.chrisbanes.accompanist:accompanist-coil:${Versions.composeAppComponist}")
 }
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.namespace == "com.android") {
-                useModule("com.android.tools.build:gradle:4.2.0-alpha16")
+                useModule("com.android.tools.build:gradle:7.0.0-alpha02")
             }
         }
     }


### PR DESCRIPTION
Since the android studio download page doesn't have the Android studio Preview 4.2 anymore - https://developer.android.com/studio/preview.

Also Jetpack compose is not supported in Android studio Beta build.
Jetpack compose only support on canary version.

So let update our Android Studio to Arctic Fox.

**Version dependencies**
- Arctic Fox required AGP 7.0.0
- Compose alpha08 require Kotlin 1.4.20